### PR TITLE
Fix to Issue 2. added X and Y attributes to code output and organized the columns

### DIFF
--- a/xAlt.py
+++ b/xAlt.py
@@ -373,17 +373,20 @@ class altRanger():
 
         self.refactor()  # reorder the layers fields
 
-        if (layer):
-            # Add the layer to the current project
-            QgsProject.instance().addMapLayer(layer)
+        # if (layer):
+        #     # Add the layer to the current project
+        #     QgsProject.instance().addMapLayer(layer)
 
-        if (minmaxLayer):
-            # Add the layer to the current project
-            QgsProject.instance().addMapLayer(minmaxLayer)
+        # if (minmaxLayer):
+        #     # Add the layer to the current project
+        #     QgsProject.instance().addMapLayer(minmaxLayer)
 
         if (orderedLayer):
             # Add the layer to the current project
             QgsProject.instance().addMapLayer(orderedLayer)
+
+        QgsProject.instance().removeMapLayer(layer)
+        QgsProject.instance().removeMapLayer(minmaxLayer)
 
 
 # main function called on start of this code


### PR DESCRIPTION
The issue relating to the X and Y components needing to be added to the attributes has been fixed using a roundabout way by adding the fields to the joined Layer and separately the data to the minmax layer, this lets us bypass the limitations of the layers not being able to update fields using the updateField() command (Also needs a fix). the code in itself can be a bit more elegant in hindsight as well.